### PR TITLE
Stop passing all props through to DOM to quell errors

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,10 @@ interface Props extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElem
   center?: boolean
 }
 
+interface FilteredProps {
+  children?: any
+}
+
 export const Div = (props: Props) => {
   const styles: React.CSSProperties = { ...props.style }
 
@@ -26,9 +30,18 @@ export const Div = (props: Props) => {
     styles.justifyContent = 'center'
   }
 
+  const disallowed = ['flex', 'wrap', 'row', 'column', 'center']
+
+  const filteredProps: FilteredProps = Object.keys(props)
+    .filter((key) => !disallowed.includes(key))
+    .reduce((obj, key) => {
+      obj[key] = props[key]
+      return obj
+    }, {})
+
   return (
-    <div {...props} style={styles}>
-      {props.children}
+    <div {...filteredProps} style={styles}>
+      {filteredProps.children}
     </div>
   )
 }


### PR DESCRIPTION
Getting errors like the following when using this library.

![image](https://user-images.githubusercontent.com/20216739/131035475-e3cad756-d5ca-4163-ac41-dcb8811ea0c0.png)

These errors are being thrown b/c we are passing props down to the actual semantic `<div>` that don't belong there. For example `<div>` does not have a property `row` and so it is complaining.

This PR filters these out.